### PR TITLE
Removing Perl 5.10 prereq

### DIFF
--- a/lib/MooseX/Types/GTIN.pm
+++ b/lib/MooseX/Types/GTIN.pm
@@ -53,7 +53,6 @@ L<http://www.state51.co.uk>.
 
 =cut
 
-use 5.10.0;
 use MooseX::Types::Moose qw/Int Str/;
 use MooseX::Types
     -declare => [qw(


### PR DESCRIPTION
A tiny pull request to remove the dependence on Perl 5.10.

This module's tests seem to run as expected with Perl 5.8.9, at least once this line is removed...
